### PR TITLE
Add unused param to receiveApproval

### DIFF
--- a/MarketPlace.sol
+++ b/MarketPlace.sol
@@ -255,7 +255,7 @@ contract MarketPlace {
     }
 
     //approveAndCall to transfer tokens into TokenMP account
-    function receiveApproval( address _grantor, uint256 _value, address _from ) public returns ( bool success_ ) {
+    function receiveApproval( address _grantor, uint256 _value, address _from,  bytes _extraData ) public returns ( bool success_ ) {
         require(!freeze);
         require(accountBalance[_from][_grantor] + _value >= accountBalance[_from][_grantor]);
         TokenERC20 localTokenFrom = TokenERC20(_from);


### PR DESCRIPTION
Resolves #1 

Other contracts may have an extra data parameter. Even though we don't use this - we need to implement it so that the method doesn't fail because the number of parameters doesn't match.